### PR TITLE
Stop creating lists on ticket and device placement

### DIFF
--- a/client/stylesheets/utils/_top_nav.scss
+++ b/client/stylesheets/utils/_top_nav.scss
@@ -4,14 +4,16 @@
   color: #FFF;
   margin: 0 -15px;
   padding: 0 15px;
+  height: 3em;
 }
 
 .top-nav_brand {
   float: left;
-  padding-top: .5em;
+  line-height: 3em;
 }
 
 .top-nav_logo {
+  vertical-align: middle;
   width: 2.125em;
 }
 

--- a/client/templates/left-nav.html
+++ b/client/templates/left-nav.html
@@ -5,13 +5,15 @@
       <section id="menu" class="lists_left-menu">
         <h2 class="lists_left-menu-title">
           My Lists
-          <a class="js-new-list link-list-new"><span class="icon icon-plus"></span></a>
+          {{#if _id}}
+            <a class="js-new-list link-list-new"><span class="icon icon-plus"></span></a>
+          {{/if}}
         </h2>
         <ul class="list-todos lists_list-links">
           {{#each lists}}
             <li class="lists_list-link">
-              <a href="{{pathFor 'listsShow'}}" class="list-todo {{activeListClass}}" title="{{title}}">
-                {{title}}
+              <a href="{{pathFor 'listsShow'}}" class="list-todo {{activeListClass}}" title="{{titleText}}">
+                {{titleText}}
               </a>
             </li>
           {{/each}}

--- a/client/templates/left-nav.js
+++ b/client/templates/left-nav.js
@@ -48,20 +48,15 @@ Template.leftNav.helpers({
     if (current.route.name === 'listsShow' && current.params._id === this._id) {
       return 'active';
     }
+  },
+  titleText: function () {
+    return this.title || Lists.defaultTitle();
   }
 });
 
 Template.leftNav.events({
   'click .js-new-list': function() {
-    Meteor.call('createList', {
-      title: Lists.defaulTitle()
-    }, function (error, listId) {
-        if(error){
-          console.log(error.reason);
-        } else {
-          Router.go('listsShow', {_id: listId});
-        }
-    });
+    Router.go('listsShow');
   },
 
   'click .js-delete-list': function(event, template) {

--- a/client/templates/lists-show.html
+++ b/client/templates/lists-show.html
@@ -2,7 +2,7 @@
   <div class="page lists-show">
     <nav class="js-title-nav lists-show_title">
       <input type="text" name="title" class="js-title-input lists-show_title-input"
-        value="{{title}}" placeholder="List Name">
+        value="{{title}}" placeholder="My New List">
 
       <input type="textarea" name="description"
         class="js-description-input lists-show_description-input" value="{{description}}"
@@ -10,12 +10,14 @@
 
       <div class="nav-group right lists-show_actions">
         <div class="options-web">
-          <a class="js-copy-list nav-item">
-            <span class="icon icon-duplicate" title="Duplicate List"></span>
-          </a>
-          <a class="js-delete-list nav-item">
-            <span class="icon icon-trashcan" title="Delete List"></span>
-          </a>
+          {{#if _id}}
+            <a class="js-copy-list nav-item">
+              <span class="icon icon-duplicate" title="Duplicate List"></span>
+            </a>
+            <a class="js-delete-list nav-item">
+              <span class="icon icon-trashcan" title="Delete List"></span>
+            </a>
+          {{/if}}
         </div>
       </div>
     </nav>

--- a/client/templates/lists-show.js
+++ b/client/templates/lists-show.js
@@ -1,7 +1,8 @@
 Template.listsShow.helpers({
 
   todosReady: function() {
-    return Router.current().todosHandle.ready();
+    var handle = Router.current().todosHandle;
+    return !handle || handle.ready();
   },
 
   todos: function(listId) {
@@ -9,14 +10,25 @@ Template.listsShow.helpers({
   }
 });
 
-var saveListTitle = function(list, template) {
-  var newTitle = template.$('[name=title]').val() || Lists.defaulTitle();
-  Meteor.call('updateList', list._id, {title: newTitle});
+var createList = function (attrs, todos) {
+  Meteor.call('createList', attrs, todos, function (error, newListId) {
+    var params;
+    if(error){
+      console.log(error.reason);
+    } else {
+      params = _.extend(Router.current().params, {_id: newListId});
+      Router.go(Router.current().route.name, params);
+    }
+  });
 };
 
-var saveListDescription = function(list, template) {
-  Meteor.call('updateList', list._id,
-    {description: template.$('[name=description]').val()});
+var updateList = function(list, newAttrs) {
+  var attrs = _.extend(list, newAttrs);
+  if(list._id){
+    Meteor.call('updateList', list._id, attrs);
+  } else {
+    createList(attrs);
+  }
 };
 
 Template.listsShow.events({
@@ -29,11 +41,11 @@ Template.listsShow.events({
   },
 
   'blur .js-title-input': function(event, template) {
-    saveListTitle(this, template);
+    updateList(this, {title: template.$('[name=title]').val()});
   },
 
   'blur .js-description-input': function(event, template) {
-    saveListDescription(this, template);
+    updateList(this, {description: template.$('[name=description]').val()});
   },
 
   'focus .js-todo-new input[type=text]': function(event, template) {
@@ -48,14 +60,23 @@ Template.listsShow.events({
     event.preventDefault();
 
     var $input = template.$('.js-todo-new input[type=text]');
+    var todo;
+
     if (! $input.val())
       return;
 
-    Meteor.call('createTodo', {
-      listId: this._id,
+    todo = {
       text: $input.val(),
       checked: false
-    });
+    };
+
+    if(!this._id){
+      createList(this, [todo]);
+    } else {
+      todo.listId = this._id;
+      Meteor.call('createTodo', todo);
+    }
+
     $input.val('');
   }
 });

--- a/client/templates/lists-show.js
+++ b/client/templates/lists-show.js
@@ -41,11 +41,21 @@ Template.listsShow.events({
   },
 
   'blur .js-title-input': function(event, template) {
-    updateList(this, {title: template.$('[name=title]').val()});
+    var newTitle = template.$('[name=title]').val();
+
+    if(newTitle === this.title ||
+      (_.isEmpty(newTitle) && _.isEmpty(this.title))){ return; }
+
+    updateList(this, {title: newTitle});
   },
 
   'blur .js-description-input': function(event, template) {
-    updateList(this, {description: template.$('[name=description]').val()});
+    var newDescription = template.$('[name=description]').val();
+
+    if(newDescription === this.description ||
+      (_.isEmpty(newDescription) && _.isEmpty(this.description))){ return; }
+
+    updateList(this, {description: newDescription});
   },
 
   'focus .js-todo-new input[type=text]': function(event, template) {

--- a/client/templates/top-nav.html
+++ b/client/templates/top-nav.html
@@ -7,20 +7,20 @@
     <ul class="top-nav_list-links">
       {{#each lists}}
         <li class="top-nav_list-link">
-          <a title="{{title}}">
-            {{title}}
+          <a title="{{titleText}}">
+            {{titleText}}
           </a>
         </li>
       {{/each}}
     </ul>
     <div class="top-nav_actions">
-      <a class="js-new-list link-list-new">New List<span class="icon icon-plus"></span></a>
+      {{#if _id}}
+        <a class="js-new-list link-list-new">New List<span class="icon icon-plus"></span></a>
+      {{/if}}
     </div>
   </div>
 
   <div class="top-nav_list-show">
-    {{#with list}}
-      {{> yield}}
-    {{/with}}
+    {{> yield}}
   </div>
 </template>

--- a/client/templates/top-nav.js
+++ b/client/templates/top-nav.js
@@ -1,16 +1,18 @@
 var deleteList = function(event, template) {
-  var list = template.data.list;
-  var item = template.data.item;
-
+  var list = template.data;
+  var params = Router.current().params;
   Meteor.call('destroyList', list._id);
 
-  Router.go('/'+item.type+'s/'+item.id);
+  Router.go('itemShow', {
+    item_id: params.item_id,
+    item_type: params.item_type
+  });
   return true;
 };
 
 var copyList = function(event, template) {
-  var list = template.data.list;
-  var item = template.data.item;
+  var list = template.data;
+  var params = Router.current().params;
   var todos = Todos.find({listId: list._id}).fetch();
   Meteor.call('createList',{
     title: "Copy of " + list.title,
@@ -21,9 +23,9 @@ var copyList = function(event, template) {
         console.log(error.reason);
       } else {
         Router.go('itemListsShow', {
-          _id: item.id,
-          item_type: item.type,
-          list_id: listCopyId
+          item_id: params.item_id,
+          item_type: params.item_type,
+          _id: listCopyId
         });
       }
   });
@@ -31,34 +33,28 @@ var copyList = function(event, template) {
 
 Template.topNav.helpers({
   lists: function() {
+    var params = Router.current().params;
     return Lists.find({
       userId: Meteor.userId(),
       linkedItems: {
         $elemMatch: {
-          type: this.item.type,
-          id: this.item.id
+          type: params.item_type,
+          id: parseInt(params.item_id)
         }
       }
     });
+  },
+  titleText: function () {
+    return this.title || Lists.defaultTitle();
   }
 });
 
 Template.topNav.events({
   'click .js-new-list': function(event, template) {
-    var item = template.data.item;
-    var list_id = Meteor.call('createList', {
-      title: Lists.defaulTitle(),
-      linkedItems: [item]
-    }, function (error, listId) {
-        if(error){
-          console.log(error.reason);
-        } else {
-          Router.go('itemListsShow', {
-            _id: item.id,
-            item_type: item.type,
-            list_id: listId
-          });
-        }
+    var params = Router.current().params;
+    Router.go('itemListsShow', {
+      item_id: params.item_id,
+      item_type: params.item_type
     });
   },
 
@@ -71,11 +67,11 @@ Template.topNav.events({
   },
 
   'click .top-nav_list-link': function (event, template) {
-    var item = template.data.item;
+    var params = Router.current().params;
     Router.go('itemListsShow', {
-      _id: item.id,
-      item_type: item.type,
-      list_id: this._id
+      item_id: params.item_id,
+      item_type: params.item_type,
+      _id: this._id
     });
   }
 });

--- a/lib/collections.js
+++ b/lib/collections.js
@@ -1,9 +1,7 @@
 Lists = new Mongo.Collection('lists');
 
-// Calculate a default name for a list in the form of 'List 123'
-Lists.defaulTitle = function() {
-  var count = Lists.find({title: /^List \d+$/}).count();
-  return 'List ' + (count + 1);
+Lists.defaultTitle = function() {
+  return 'My New List';
 };
 
 Todos = new Mongo.Collection('todos');

--- a/lib/router.js
+++ b/lib/router.js
@@ -48,23 +48,6 @@ var bootstrapLists = function () {
   }
 };
 
-var bootstrapItemList = function (item) {
-  var itemListsCount = Lists.find({
-    userId: Meteor.userId(),
-    linkedItems: { $elemMatch: {type: item.type, id: item.id}}
-  }).count();
-  if (itemListsCount === 0) {
-    Meteor.call('createList', {
-      title: Lists.defaulTitle(),
-      linkedItems:[{
-        id: item.id,
-        type: item.type,
-        name: item.name
-      }]
-    });
-  }
-};
-
 Router.configure({
   // we use the  appBody template to define the layout for the entire app
   layoutTemplate: 'application',
@@ -85,7 +68,6 @@ Router.configure({
   }
 });
 
-userReadyHold = null;
 card = null;
 
 if (Meteor.isClient) {
@@ -107,12 +89,18 @@ if (Meteor.isClient) {
 }
 
 Router.route('listsShow', {
-  path: '/lists/:_id',
+  path: '/lists/:_id?',
   onBeforeAction: function () {
-    this.todosHandle = Meteor.subscribe('todos', this.params._id);
+    if(this.params._id){
+      this.todosHandle = Meteor.subscribe('todos', this.params._id);
+    }
   },
   data: function () {
-    return Lists.findOne(this.params._id);
+    if(this.params._id){
+      return Lists.findOne(this.params._id);
+    } else {
+      return {};
+    }
   },
   action: function () {
     this.render('fullPagePlacement');
@@ -120,87 +108,43 @@ Router.route('listsShow', {
 });
 
 Router.route('itemListsShow', {
-  path: '/:item_type/:_id/list/:list_id',
+  path: '/:item_type/:item_id/list/:_id?',
   onBeforeAction: function () {
-    this.todosHandle = Meteor.subscribe('todos', this.params.list_id);
+    if(this.params._id){
+      this.todosHandle = Meteor.subscribe('todos', this.params._id);
+    }
   },
   data: function () {
-    var list = Lists.findOne(this.params.list_id);
-    var itemId = this.params._id;
-    var itemType = this.params.item_type;
-    var item = _.find(list.linkedItems, function (linkedItem) {
-      return linkedItem.type === itemType && linkedItem.id === itemId;
-    });
-    return {
-      list: list,
-      item: item
-    };
+    var item = Session.get('item');
+    var list;
+
+    if(this.params._id){
+      list = Lists.findOne(this.params._id);
+    } else {
+      list = {
+        linkedItems: [item]
+      };
+    }
+    return list;
   },
   action: function () {
     this.render('itemPlacement');
   }
 });
 
-Router.route('ticketsShow', {
-  path: '/tickets/:_id',
-  waitOn: function () {
-    card.services('helpdesk').request('ticket', parseInt(this.params._id))
-    .then(function (ticket) {
-      Session.set({
-        itemName: ticket.summary,
-        itemType: 'ticket'
-      });
-    });
-    return [function () {
-      return Session.get('itemName');
-    },function () {
-      return Session.get('itemType');
-    }];
-  },
-  action: function () {
-    bootstrapItemList({
-      type:'ticket',
-      id: this.params._id,
-      name: Session.get('itemName')});
-    Router.go('itemListsShow', {
-      _id: this.params._id,
-      item_type: 'ticket',
-      list_id: Lists.findOne({
-        userId: Meteor.userId(),
-        linkedItems: {$elemMatch: {type: 'ticket', id: this.params._id}}
-      })._id
-    });
-  }
-});
 
-Router.route('devicesShow', {
-  path: '/devices/:_id',
-  waitOn: function () {
-    card.services('inventory').request('device', parseInt(this.params._id))
-    .then(function (device) {
-      Session.set({
-        itemName: device.name,
-        itemType: 'device'
-      });
-    });
-    return [function () {
-      return Session.get('itemName');
-    },function () {
-      return Session.get('itemType');
-    }];
-  },
+Router.route('itemShow', {
+  path: '/:item_type/:item_id',
   action: function () {
-    bootstrapItemList({
-      type:'device',
-      id: this.params._id,
-      name: Session.get('itemName')});
+    var firstList = Lists.findOne({
+      userId: Meteor.userId(),
+      linkedItems: {$elemMatch: {
+        type: this.params.item_type, id: parseInt(this.params.item_id)}}
+    });
     Router.go('itemListsShow', {
-      _id: this.params._id,
-      item_type: 'device',
-      list_id: Lists.findOne({
-        userId: Meteor.userId(),
-        linkedItems: {$elemMatch: {type: 'device', id: this.params._id}}
-      })._id
+      item_id: this.params.item_id,
+      item_type: this.params.item_type,
+      _id: firstList && firstList._id
     });
   }
 });
@@ -209,14 +153,21 @@ Router.route('devices', {
   path: '/devices',
   waitOn: function () {
     card.services('inventory').on('device:show', function (deviceId) {
-      Session.set('itemId', deviceId.toString());
+      card.services('inventory').request('device', deviceId)
+        .then(function (device) {
+          Session.set('item', {
+            id: device.id,
+            type: 'device',
+            name: device.name
+          });
+        });
     });
     return function () {
-      return Session.get('itemId');
+      return Session.get('item');
     };
   },
   action: function () {
-    Router.go('devicesShow', {_id: Session.get('itemId')});
+    Router.go('itemShow', {item_id: Session.get('item').id, item_type: 'device'});
   }
 });
 
@@ -224,14 +175,21 @@ Router.route('tickets', {
   path: '/tickets',
   waitOn: function () {
     card.services('helpdesk').on('showTicket', function (ticketId) {
-      Session.set('itemId', ticketId.toString());
+      card.services('helpdesk').request('ticket', ticketId)
+        .then(function (ticket) {
+          Session.set('item', {
+            id: ticket.id,
+            type: 'ticket',
+            name: ticket.summary
+          });
+        });
     });
     return function () {
-      return Session.get('itemId');
+      return Session.get('item');
     };
   },
   action: function () {
-    Router.go('ticketsShow', {_id: Session.get('itemId')});
+    Router.go('itemShow', {item_id: Session.get('item').id, item_type: 'ticket'});
   }
 });
 


### PR DESCRIPTION
Updated the router so that when the device or ticket placement loads, it
does not create a new list automatically.
Now, any time any of the placements load without a list ID, they create 
an unsaved list object, which will only get save once an update is made 
to the list.
Simplified the router, so that the SW ticket and device info are 
gathered at the same time before the client side redirect.
Fixed the height of the top nav on the device and ticket placements to 
prevent jumping when the nav gets its first list.
Changed the default list title to simply ‘My New List’.
No longer display the new list, copy list, or delete list buttons on a 
new list that has yet to be saved.
Now send up the entire list object when any field is updated, just to 
keep it simple with a single code path.

Fixes #1.
